### PR TITLE
add vologray-800 to tailwind.config.js, set prop 'gray' for ButtonSta…

### DIFF
--- a/src/components/ButtonStandard.vue
+++ b/src/components/ButtonStandard.vue
@@ -1,9 +1,18 @@
 <template>
-  <button class="border rounded-lg text-white text-sm bg-voloblue-200 px-6 h-11">
+  <!-- button standard is blue, for gray version use prop 'gray' -->
+  <button
+    class="border rounded-lg text-white text-sm bg-voloblue-200 px-6 h-11"
+    :class="{
+      'bg-vologray-800': gray
+    }"
+  >
     <slot></slot>
   </button>
 </template>
 
 <script>
-export default {}
+export default {
+  name: 'ButtonStandard',
+  props: ['gray']
+}
 </script>

--- a/src/components/ProjectFormular.vue
+++ b/src/components/ProjectFormular.vue
@@ -135,7 +135,7 @@
       <IconSpinner />speichere daten...
     </div>
     <footer class="flex justify-between p-6 border-solid border-t border-vologray-200">
-      <ButtonStandard @click.prevent="$emit('close')">Abbrechen</ButtonStandard>
+      <ButtonStandard @click.prevent="$emit('close')" :gray="true">Abbrechen</ButtonStandard>
       <p
         class="flex justify-center text-sm font-light rounded border border-1 mb-4 p-3 bg-red-100 border-red-500 text-red-500"
         v-if="pageOneErr === true"

--- a/src/components/VolunteerFormular.vue
+++ b/src/components/VolunteerFormular.vue
@@ -72,7 +72,7 @@
       </div>
     </main>
     <footer class="flex justify-between p-6 border-solid border-t border-vologray-200">
-      <ButtonStandard @click.prevent="$emit('cancel')">Abbrechen</ButtonStandard>
+      <ButtonStandard @click.prevent="$emit('cancel')" :gray="true">Abbrechen</ButtonStandard>
       <ButtonStandard type="submit" form="new-volunteer">Freiwillige:n anlegen</ButtonStandard>
     </footer>
   </section>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,7 +11,8 @@ export default {
           400: '#A5A5A5', // text-color
           500: '#979797', // bg-color
           600: '#7B7F8E', // bg-modal
-          700: '#8C97AF' // table head text / magnifier icon
+          700: '#8C97AF', // table head text / magnifier icon
+          800: '#6E6E6E' // ButtonStandard
         },
         voloblue: {
           100: '#0049FF',


### PR DESCRIPTION
…ndard and change color for 'quit' buttons in project and volunteer formular

>>> realized that the ButtonStandard in the ProjectFormular has a opacity - is that right?

<ButtonStandard
        type="submit"
        form="new-project"
        :disabled="currentPage === 1"
        :class="{ 'bg-opacity-70': currentPage === 1 }"
        >Einsatzstelle anlegen</ButtonStandard
      >